### PR TITLE
fix: Windows cannot load screenshot

### DIFF
--- a/uiviewer/_device.py
+++ b/uiviewer/_device.py
@@ -3,6 +3,7 @@
 import abc
 import traceback
 import tempfile
+import os
 from typing import List, Dict, Union, Tuple, Optional
 from functools import cached_property  # python3.8+
 
@@ -55,10 +56,14 @@ class HarmonyDevice(DeviceMeta):
         return self.hdc.display_size()
 
     def take_screenshot(self) -> str:
+        png_base64 = None
         with tempfile.NamedTemporaryFile(delete=True, suffix=".png") as f:
             path = f.name
+            f.close()
             self.hdc.screenshot(path)
-            return file2base64(path)
+            png_base64 = file2base64(path)
+            os.remove(path)
+        return png_base64
 
     def dump_hierarchy(self) -> BaseHierarchy:
         packageName, pageName = self.hdc.current_app()


### PR DESCRIPTION
a temporary file handle created by tempfile can
not be reopened by other processes rewritted on Windows

windows下tempfile创建的临时文件句柄在被外部写入时不能被再次打开

我用了一个比较粗暴的方法先解决bug了，你可以看看再改改，改得优雅点